### PR TITLE
Remove unnecessary imports to solve reference cycle issue

### DIFF
--- a/ZendeskSDK.framework/Headers/ZDKImageViewerViewController.h
+++ b/ZendeskSDK.framework/Headers/ZDKImageViewerViewController.h
@@ -15,7 +15,7 @@
  */
 
 #import <UIKit/UIKit.h>
-#import <ZendeskSDK/ZendeskSDK.h>
+@class ZDKUIViewController;
 
 
 @interface ZDKImageViewerViewController : ZDKUIViewController<UIScrollViewDelegate>

--- a/ZendeskSDK.framework/Headers/ZDKUILoadingView.h
+++ b/ZendeskSDK.framework/Headers/ZDKUILoadingView.h
@@ -14,7 +14,7 @@
  *
  */
 
-#import <ZendeskSDK/ZendeskSDK.h>
+
 
 @interface ZDKUILoadingView : UIView
 


### PR DESCRIPTION
ideally it should be fixed in the source code instead of in the public header. You may want to do that internally.