### PR TITLE
Adding some framework dependancies to the podspec

### DIFF
--- a/ZendeskSDK.podspec
+++ b/ZendeskSDK.podspec
@@ -24,6 +24,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/zendesk/zendesk_sdk_ios.git", :tag => s.version }
   s.platform     = :ios, '6.0'
   s.requires_arc = true
+  s.frameworks = 'MobileCoreServices', 'SystemConfiguration', 'Security'
 
   # Using subspecs to support installation without Localization part
   s.default_subspecs = 'Core', 'Localization'


### PR DESCRIPTION
# Changes 

- Adding MobileCoreServices, SystemConfiguration and Security frameworks to the pod spec. 

## Reviewers
@StevenDiviney @RonanMcH 