### PR TITLE
Fixed imports to work with CocoaPods, use_frameworks! and Swift

### DIFF
--- a/ZendeskSDK.framework/Headers/ZDKRequests.h
+++ b/ZendeskSDK.framework/Headers/ZDKRequests.h
@@ -15,8 +15,8 @@
  */
 
 
-#import <Foundation/Foundation.h>
-#import <ZendeskProviderSDK/ZendeskProviderSDK.h>
+@import Foundation;
+@import ZendeskProviderSDK;
 
 
 #import "ZDKCreateRequestUIDelegate.h"


### PR DESCRIPTION
ZDKRequests.h attempts to use non-modular includes and then use CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES.

According to this thread (https://forums.developer.apple.com/thread/23554 -- see the final comment, ddunbar, Apple Staff, Oct 27, 2015) -- NOTE: The "Allow Non-modular includes in Framework Modules" build setting does not apply to Swift (and it would not be safe if it did, Swift requires access to modules for proper debugging support).

Additionally, on Aug 31, nonichu on CocoaPods commented regarding these types of issues: "Pod authors will have to fix their Pods so that they work correctly as modules".  (https://github.com/CocoaPods/CocoaPods/issues/3847)

Converting these imports to @import of the module solves theses issues.

Environment:
 - Xcode -- Version 7.1.1 (7B1005)
 - CocoaPods -- Version 0.39.0
 - Language: Swift

I created a test Swift project that can be used to demonstrate the issue and then used to test a fix:  https://github.com/foscomputerservices/TestZenDesk.git