### PR TITLE
Remove iOS 10 notice from public repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,6 @@ You can find [documentation](https://developer.zendesk.com/embeddables/docs/ios/
 
 All enhancement, improvement, and feature request suggestions are welcomed. Please submit them to our [SDK community](https://support.zendesk.com/hc/en-us/community/topics/200488257-Zendesk-SDKs). We will normally close feature requests posted to this repository.
 
-## A note regarding iOS 10
-
-We are aware that there are issues with the SDK when testing on iOS 10. We are currently working on a release of the SDK that addresses these issues, in line with our policy of supporting the current and previous two versions of iOS. If you find any iOS 10 specific issues, please feel free to submit them.
-
 ## Copyright and license
 
 Copyright 2014 Zendesk


### PR DESCRIPTION
## Changes

How embarrassing! We still had a notice on our public Support SDK repo that we were working on an iOS 10-friendly release. Oops.

This update removes the notice.

## Reviewers

@baz8080 @tecknut @RonanMcH @brendan-fahy @chucknado 

## References

![](https://media.giphy.com/media/l46C8cOHW1D8vuSoo/giphy.gif)

## FYI

## Risks